### PR TITLE
Update driver to allow setting the name through an options object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,15 +5,18 @@ function degToRad(x) {
   return x * ( Math.PI / 180 );
 }
 
-var Photocell = module.exports = function() {
+var Photocell = module.exports = function(opts) {
   Device.call(this);
+  this.opts = opts || {};
   this.intensity = 0;
 };
 util.inherits(Photocell, Device);
 
 Photocell.prototype.init = function(config) {
+  var name = this.opts.name || 'photocell';
+
   config
-    .name('photocell')
+    .name(name)
     .type('photocell')
     .monitor('intensity');
 


### PR DESCRIPTION
For voltron having the name be configurable would be delightful. 

This case is now supported.

```
var zetta = require('zetta');
var photocell = require('zetta-photocell-mock-driver');

zetta()
  .use(photocell, { name: 'foo' })
  .listen(1337);
```
