### PR TITLE
added `ready` and `not-ready` states. new versions of zetta-device and zetta. additional example apps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules/
 npm-debug.log
 .DS_Store
 .peers
-.registry
+.devices

--- a/example/apps/intermittent-connection.js
+++ b/example/apps/intermittent-connection.js
@@ -1,0 +1,8 @@
+module.exports = function(server) {
+  var photocellQuery = server.where({ type: 'photocell' });
+  server.observe([photocellQuery], function(photocell){
+    setInterval(function(){
+      (photocell.state == 'ready') ? photocell.call('make-not-ready') : photocell.call('make-ready');
+    }, 1000);
+  });
+};

--- a/example/apps/style.js
+++ b/example/apps/style.js
@@ -1,0 +1,32 @@
+var util = require('util');
+var extend = require('node.extend');
+
+var IMAGE_URL_ROOT = 'http://www.zettaapi.org/icons/';
+var IMAGE_EXTENSION = '.png';
+
+var stateImageForDevice = function(device) {
+  return IMAGE_URL_ROOT + device.type + '-' + device.state + IMAGE_EXTENSION;
+}
+
+module.exports = function(server) {
+  var deviceQuery = server.where({ type: 'photocell' });
+  server.observe([deviceQuery], function(device) {
+
+    var states = Object.keys(device._allowed);
+    for (i = 0; i < states.length; i++) {
+      device._allowed[states[i]].push('update-style');
+    }
+    device._transitions['update-style'] = {
+      handler: function(updatedStyle, cb) {
+        this.style = extend(this.style, updatedStyle);
+        cb();
+      }
+    };
+
+    device.call('update-style', {stateImage: stateImageForDevice(device)});
+    var stateStream = device.createReadStream('state');
+    stateStream.on('data', function(newState) {
+      device.call('update-style', {stateImage: stateImageForDevice(device)});
+    });
+  });
+}

--- a/example/package.json
+++ b/example/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "zetta": "^0.11.0"
+    "node.extend": "^1.1.5",
+    "zetta": "^1.0.0-beta.6"
   }
 }

--- a/example/server.js
+++ b/example/server.js
@@ -1,6 +1,8 @@
 var zetta = require('zetta');
 var Photocell = require('../index');
+var style = require('./apps/style');
 
 zetta()
   .use(Photocell)
+  .use(style)
   .listen(1337);

--- a/example/server.js
+++ b/example/server.js
@@ -1,8 +1,9 @@
 var zetta = require('zetta');
 var Photocell = require('../index');
 var style = require('./apps/style');
-
+var intermittentConnection = require('./apps/intermittent-connection');
 zetta()
   .use(Photocell)
   .use(style)
+  .use(intermittentConnection)
   .listen(1337);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ Photocell.prototype.init = function(config) {
   config
     .name('photocell')
     .type('photocell')
+    .state('ready')
+    .when('ready', {allow: ['make-not-ready']})
+    .when('not-ready', {allow: ['make-ready']})
+    .map('make-ready', this.makeReady)
+    .map('make-not-ready', this.makeNotReady)
     .monitor('intensity');
 
   var self = this;
@@ -24,3 +29,13 @@ Photocell.prototype.init = function(config) {
     counter += 15;
   }, 100);
 };
+
+Photocell.prototype.makeReady = function(cb) {
+  this.state = 'ready';
+  cb();
+}
+
+Photocell.prototype.makeNotReady = function(cb) {
+  this.state = 'not-ready'
+  cb();
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "homepage": "https://github.com/zettajs/zetta-photocell-mock-driver",
   "dependencies": {
-    "zetta-device": "^0.15.0"
+    "zetta-device": "^0.18.0"
   }
 }


### PR DESCRIPTION
- added `ready` and `not-ready` states
- added related `make-ready` and `make-not-ready` transitions
- included `style` example app
- included `intermittent-connection` app

if you're cool with the pull request, please also bump and publish to npm.
